### PR TITLE
Simplify filters.

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,17 +32,13 @@ $(document).ready( function () {
 
   // pointers to form elements
   const systemFilterField = $("#system-field");
-  const sornFilterField = $("#sorn-field");
   const piiFilterField = $("#pii-field");
   const piaCheckbox = $("#filter__PIA")
   const sornCheckbox = $("#filter__SORNS")
-  const ssnCheckbox = $("#filter__SSN")
-  const emailCheckbox = $("#filter__email")
 
   // Set up hash to hold search and filter data as needed
   var SearchFilterData = {
     system: null,
-    sorn: null,
     pii: null,
     generalSearch: null
   };
@@ -51,29 +47,22 @@ $(document).ready( function () {
   function filter() {
     // get latest filter data
     SearchFilterData.system = systemFilterField.val().toLowerCase()
-    SearchFilterData.sorn = sornFilterField.val().toLowerCase()
     SearchFilterData.pii = piiFilterField.val().toLowerCase()
 
     list.filter( function(item) {
       // for each card, get lower case values
       var systemName = item.values()["system"].toLowerCase()
-      var sornID = item.values()["sorn-id"].toLowerCase()
       var piiValue = item.values()["pii"].toLowerCase()
       var type = item.values()["type"]
 
       // Set filter value to true (include) if search text is contained in field
       // OR if there is no value entered in the field
       var systemFilter = systemName.includes(SearchFilterData.system) || !SearchFilterData.system
-      var sornIdFilter = sornID.includes(SearchFilterData.sorn) || !SearchFilterData.sorn
       var piiFilter = piiValue.includes(SearchFilterData.pii) || !SearchFilterData.pii
 
       // document type filters are true (include) by default
       var piaFilter = true
       var sornFilter = true
-
-      // Quick filters are true by default
-      var ssnFilter = true
-      var emailFilter = true
 
       // if PIA document type checkbox is not checked, apply filter for that type
       if (!piaCheckbox.is(":checked")) {
@@ -85,16 +74,8 @@ $(document).ready( function () {
         sornFilter = !type.includes("SORN")
       }
 
-      if (ssnCheckbox.is(":checked")) {
-        ssnFilter = piiValue.includes("ssn")
-      }
-
-      if (emailCheckbox.is(":checked")) {
-        emailFilter = piiValue.includes("email")
-      }
-
       // display item if all conditions are true, otherwise filter
-      if (ssnFilter && emailFilter && systemFilter && sornIdFilter && piiFilter && piaFilter && sornFilter) {
+      if (systemFilter && piiFilter && piaFilter && sornFilter) {
         return true;
       } else {
         return false;
@@ -103,7 +84,7 @@ $(document).ready( function () {
   }
 
   function setTypedFilterTags() {
-    var typedFilterKeys = ['system', 'sorn', 'pii'] // Add any new typed filter keys here
+    var typedFilterKeys = ['system', 'pii'] // Add any new typed filter keys here
     for (key of typedFilterKeys) {
       var tag = $(`#${key}-tag`);
       var tagExists = tag.length;
@@ -119,23 +100,6 @@ $(document).ready( function () {
     }
   }
 
-  function setQuickFilterTags() {
-    // Quick filters
-    if (ssnCheckbox.is(":checked") && !$("#ssn-tag").length) {
-      html = `<li id="ssn-tag" class="usa-tag">PII: SSN</li>`
-      $("#active-filters").append(html)
-    } else if (!ssnCheckbox.is(":checked") && $("#ssn-tag").length){
-      $(`#ssn-tag`).remove()
-    }
-
-    if (emailCheckbox.is(":checked") && !$("#email-tag").length) {
-      html = `<li id="email-tag" class="usa-tag">PII: email</li>`
-      $("#active-filters").append(html)
-    } else if (!emailCheckbox.is(":checked") && $("#email-tag").length) {
-      $(`#email-tag`).remove()
-    }
-  }
-
   function highlight() {
     // highlight matching search results
     $('ul.pii li.highlight').removeClass('highlight');
@@ -143,20 +107,12 @@ $(document).ready( function () {
       $(`ul.pii li:icontains(${SearchFilterData.pii})`).addClass('highlight')
     }
 
-    if (ssnCheckbox.is(":checked")) {
-      $(`ul.pii li:icontains(SSN)`).addClass('highlight')
-    }
-
-    if (emailCheckbox.is(":checked")) {
-      $(`ul.pii li:icontains(email)`).addClass('highlight')
-    }
-
     if (SearchFilterData.generalSearch) {
       $(`ul.pii li:icontains(${SearchFilterData.generalSearch})`).addClass('highlight')
     }
   }
 
-  const checkboxes = [piaCheckbox, sornCheckbox, ssnCheckbox, emailCheckbox]
+  const checkboxes = [piaCheckbox, sornCheckbox]
   // bind checkbox click() action to trigger the filter() function
   checkboxes.forEach(
     checkbox => checkbox.click( function() {
@@ -167,7 +123,7 @@ $(document).ready( function () {
   )
 
   // Bind keypresses on each of the search boxes
-  const filters = [systemFilterField, sornFilterField, piiFilterField]
+  const filters = [systemFilterField, piiFilterField]
   filters.forEach(
     search => search.keyup( function() {
       filter()
@@ -217,30 +173,9 @@ $(document).ready( function () {
     <div class="grid-row grid-gap">
       <div class="usa-list desktop:grid-col-3">
         <div class="filter_section padding-2">
-          <ul class="margin-top-0">
-            <li>
-              <span><strong>FILTERS</strong></span>
-            </li>
-            <li>
-              <span>QUICK FILTERS</span>
-            </li>
-            <li>
-              <div class="usa-checkbox float-left checkbox-tags">
-                <input class="usa-checkbox__input" type="checkbox" id="filter__SSN" name="SSN" value="SSN">
-                <label class="usa-checkbox__label margin-bottom-0" id="filter__SSN_label" for="filter__SSN">SSN</label>
-              </div>
-              <div class="usa-checkbox float-left checkbox-tags">
-                <input class="usa-checkbox__input" type="checkbox" id="filter__email" name="Email" value="Email">
-                <label class="usa-checkbox__label margin-bottom-0" id="filter__email_label" for="filter__email">Email</label>
-              </div>
-            </li>
-           </ul>
+          <span><strong>FILTERS</strong></span>
 
-           <ul class="margin-top-8">
-             <hr class="margin-bottom-2">
-            <li class="margin-bottom-05">
-              <span>CUSTOM FILTERS</span>
-            </li>
+          <ul>
             <li>
               <span><strong>TYPE</strong></span>
             </li>
@@ -262,10 +197,6 @@ $(document).ready( function () {
             <li>
               <label class="" for="search-field">System</label>
               <input class="usa-input" id="system-field" type="input" name="system">
-            </li>
-            <li>
-              <label class="" for="search-field">SORN ID</label>
-              <input class="usa-input" id="sorn-field" type="input" name="sorn id">
             </li>
             <li>
               <label class="" for="search-field">PII</label>

--- a/spec/card_spec.rb
+++ b/spec/card_spec.rb
@@ -25,12 +25,9 @@ context "the card page", type: :feature, js: true do
 
     it "has filter elements" do
       expect(page).to have_selector "#system-field"
-      expect(page).to have_selector "#sorn-field"
       expect(page).to have_selector "#pii-field"
       expect(page).to have_selector("#filter__PIA", visible: false)
       expect(page).to have_selector("#filter__SORNS", visible: false)
-      expect(page).to have_selector("#filter__SSN", visible: false)
-      expect(page).to have_selector("#filter__email", visible: false)
     end
   
     it "cards have the expected elements" do
@@ -160,64 +157,7 @@ context "the card page", type: :feature, js: true do
     end
   end
 
-  context "Quick filters" do
-    describe "clicking on SSN" do
-      it "filters the list" do
-        find("#filter__SSN_label").click
-
-        expect(find("#result-count").text).to eq "2"
-        expect(all('.card').length).to eq 2
-
-        expect(all('.pii')[0].text.downcase).to include "ssn"
-        expect(all('.pii')[1].text.downcase).to include "ssn"
-      end
-
-      it "shows an active filter pill" do
-        find("#filter__SSN_label").click
-
-        expect(find("#ssn-tag")).to be_truthy
-        expect(find("#ssn-tag").text).to eq "PII: SSN"
-      end
-
-      it "highlights the matching pii" do
-        find("#filter__SSN_label").click
-
-        # test data has 2 matches, upper and lower case
-        expect(all('.highlight').count).to eq 2
-        all('.highlight').each do |li|
-          expect(li.text).to match(/SSN/i)
-        end
-      end
-    end
-
-    describe "clicking on email" do
-      it "filters the list" do
-        find("#filter__email_label").click
-
-        expect(find("#result-count").text).to eq "1"
-        expect(all('.card').length).to eq 1
-
-        expect(all('.pii')[0].text.downcase).to include "email"
-      end
-
-      it "shows an active filter pill" do
-        find("#filter__email_label").click
-
-        expect(find("#email-tag")).to be_truthy
-        expect(find("#email-tag").text).to eq "PII: EMAIL"
-      end
-
-      it "highlights the matching pii" do
-        find("#filter__email_label").click
-
-        # test data has 1 match
-        expect(all('.highlight').count).to eq 1
-        expect(find('.highlight').text).to eq "email"
-      end
-    end
-  end
-
-  context "Custom filters" do
+  context "Type filters" do
     describe "clicking on SORN" do
       it "filters the list" do
         find("#filter__SORN_label").click
@@ -282,30 +222,6 @@ context "the card page", type: :feature, js: true do
         it "removes the active filter tag" do
            expect(page).not_to have_selector("#system-tag")
         end
-      end
-    end
-
-    describe "typing in SORN ID search" do
-      it "filters the list" do
-        find("#sorn-field").set("GSA/PPFM-11")
-
-        expect(find("#result-count").text).to eq "1"
-        expect(all('.card').length).to eq 1
-        expect(find(".sorn-id").text).to eq "GSA/PPFM-11"
-      end
-
-      it "shows an active filter pill" do
-        find("#sorn-field").set("GSA/PPFM-11")
-
-        expect(find("#sorn-tag")).to be_truthy
-        expect(find("#sorn-tag").text).to eq "SORN: GSA/PPFM-11"
-      end
-
-      it "shows all cards again when search field is erased" do
-        find("#sorn-field").set("")
-
-        expect(find("#result-count").text).to eq "4"
-        expect(all('.card').length).to eq 4
       end
     end
 


### PR DESCRIPTION
This PR simplifies the available filters. It removes the Quick Filter section that had the SSN and Email checkboxes, as well as filtering on SORN ID.

[Live preview](https://cg-9341b8ea-025c-4fe2-aa6c-850edbebc499.app.cloud.gov/preview/18f/privacy-dashboard/simpler/)

<img width="1008" alt="Screen Shot 2020-03-30 at 3 41 53 PM" src="https://user-images.githubusercontent.com/595778/77968778-ffc84100-729c-11ea-89eb-00d67eb888a1.png">
