### PR TITLE
Added google analytics

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -39,4 +39,13 @@ site, this is the place to do it.
   type = "text/css"
   href = "//cdn.datatables.net/plug-ins/1.10.20/features/searchHighlight/dataTables.searchHighlight.css" />
   
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-162360106-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'UA-162360106-1');
+  </script>
 </head>


### PR DESCRIPTION
Adds google analytics. I still need to give access to everyone.

The purpose of this analytics is for us to learn. Once the site get sits own url and becomes more adopted, we need to add our site to https://analytics.usa.gov/.